### PR TITLE
add helper

### DIFF
--- a/Qconf.php
+++ b/Qconf.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @author: RunnerLee
+ * @email: runnerleer@gmail.com
+ * @time: 2017-06
+ */
+
+class Qconf
+{
+
+    /**
+     * @param $key
+     * @param $idc
+     * @param $get_flag
+     * @return string|null
+     */
+    public function getConf($key, $idc = null, $get_flag = null)
+    {
+    }
+
+    /**
+     * @param $key
+     * @param $idc
+     * @param $get_flag
+     * @return string|array|null
+     */
+    public function getBatchKeys($key, $idc = null, $get_flag = null)
+    {
+    }
+
+    /**
+     * @param $path
+     * @param $idc
+     * @param $get_flag
+     * @return array|null
+     */
+    public function getAllHost($path, $idc = null, $get_flag = null)
+    {
+    }
+
+    /**
+     * @param $path
+     * @param $idc
+     * @param $get_flag
+     * @return string|null
+     */
+    public function getHost($path, $idc = null, $get_flag = null)
+    {
+    }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
         "files": [
             "helpers.php"
         ]
+    },
+    "autoload-dev": {
+        "files": [
+            "Qconf.php"
+        ]
     }
 }


### PR DESCRIPTION
用于本地调试时没有安装 Qconf 扩展使用